### PR TITLE
Adjust minimum fontsize of WebView

### DIFF
--- a/qml/pages/WebPage.qml
+++ b/qml/pages/WebPage.qml
@@ -61,6 +61,8 @@ Page {
                             "Mozilla/5.0 (Maemo; Linux; Jolla; Sailfish; Mobile) " +
                             "AppleWebKit/534.13 (KHTML, like Gecko) " +
                             "NokiaBrowser/8.5.0 Mobile Safari/534.13";
+                    experimental.preferences.minimumFontSize =
+                            Theme.fontSizeExtraSmall * (configFontScale.value / 100.0)
                 }
                 catch (err)
                 {


### PR DESCRIPTION
This addjusts the minimum font size of the WebView to a more readable default
(Theme.fontSizeExtraSmall). Additionally the scaling setting from the config
is applied to that.