### PR TITLE
Don't break if <pubDate> contains whitespaces

### DIFF
--- a/qml/pages/RssModel.qml
+++ b/qml/pages/RssModel.qml
@@ -27,11 +27,11 @@ XmlListModel {
             "declare namespace content = 'http://purl.org/rss/1.0/modules/content/';" +
             "declare namespace itunes = 'http://www.itunes.com/DTDs/Podcast-1.0.dtd';"
 
-    XmlRole { name: "uid"; query: "guid/string()" }
-    XmlRole { name: "title"; query: "title/string()" }
-    XmlRole { name: "link"; query: "link/string()" }
+    XmlRole { name: "uid"; query: "normalize-space(guid/string())" }
+    XmlRole { name: "title"; query: "normalize-space(title/string())" }
+    XmlRole { name: "link"; query: "normalize-space(link/string())" }
     XmlRole { name: "description"; query: "description/string()" }
-    XmlRole { name: "encoded"; query: "content:encoded/string()" }
+    XmlRole { name: "encoded"; query: "normalize-space(content:encoded/string())" }
     XmlRole { name: "dateString"; query: "normalize-space(pubDate/string())" }
 
     XmlRole { name: "duration"; query: "media:content/@duration/string()" }

--- a/qml/pages/RssModel.qml
+++ b/qml/pages/RssModel.qml
@@ -32,7 +32,7 @@ XmlListModel {
     XmlRole { name: "link"; query: "link/string()" }
     XmlRole { name: "description"; query: "description/string()" }
     XmlRole { name: "encoded"; query: "content:encoded/string()" }
-    XmlRole { name: "dateString"; query: "pubDate/string()" }
+    XmlRole { name: "dateString"; query: "normalize-space(pubDate/string())" }
 
     XmlRole { name: "duration"; query: "media:content/@duration/string()" }
 


### PR DESCRIPTION
Some feeds (e.g. http://www.factorio.com/blog/rss) contain multi-lined `<pubDate>` or `<link>` elements like this:
```xml
<pubDate>
Fri, 04 Mar 2016 17:30:00 +0000
</pubDate>
<link>
http://www.factorio.com/blog/post/fff-128
</link>
```
The leading `\n` whitespace seems to upset the [DateParser](https://github.com/pycage/tidings/blob/master/src/dateparser.h#L42), so the feed entries in the App were shown mixed up and with wrong dates ("458 months ago").

Also, opening the full version of an entry resulted in 'file not found' errors on the console when the `<link>` contained leading whitespaces, since QUrl did not recognize the http:// and treated the link as relative local file path instead.

While I was at it, I also trimmed the `title`, `uid` and `encoded` fields, too.
(I left out `description`, since the [XPath function](https://developer.mozilla.org/en-US/docs/Web/XPath/Functions/normalize-space) `normalize-spaces` also removes double occurrences of whitespaces inside the string, and the `description` may contain multi-lined text with `\n\n` to separate paragraphs.)

I successfully tested this fix on the tablet by manually editing `/usr/share/harbour-tidings/qml/pages/RssModel.qml` with the App installed from Jolla Harbour.