### PR TITLE
Fix Russian translation

### DIFF
--- a/translations/harbour-tidings-ru_RU.ts
+++ b/translations/harbour-tidings-ru_RU.ts
@@ -540,7 +540,7 @@
     <message>
         <location filename="../qml/harbour-tidings.qml" line="228"/>
         <source>Loading from cache</source>
-        <translation>Загрузить из кэша</translation>
+        <translation>Загрузка из кэша</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
A small fix for the string shown while loading news from cache. Old "To load from cache" -> "Loading from cache" (in Russian)